### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/SecurityDepositDemand/data/questions/security_deposit_demand_letter.yml
+++ b/docassemble/SecurityDepositDemand/data/questions/security_deposit_demand_letter.yml
@@ -531,7 +531,7 @@ review:
   - Edit: landlord_person_name
     button: |
 	    **Landlord name:**
-      ${landlord.name.full(middle="full")}
+      ${landlord.name_full()}
     show if: landlord_type == "Person"
   - Edit: landlord_company_name
     button: |
@@ -546,7 +546,7 @@ review:
   - Edit: property_manager.name.first
     button: |
 	    **Property manager name:**
-	    ${property_manager.name.full(middle="full")}
+	    ${property_manager.name_full()}
     show if: landlord_has_agent and landlord_type == "Company"
   - Edit: landlord.address.address
     button: |
@@ -555,7 +555,7 @@ review:
   - Edit: user.name.first
     button: |
       **Your name:**
-      ${user.name.full(middle="full")}
+      ${user.name_full()}
   - Edit: mailing_address.address
     button: |
       **Your mailing address:**
@@ -577,7 +577,7 @@ review:
   - Edit: user.name.first
     button: |
       **Your name:**
-      ${user.name.full(middle="full")}
+      ${user.name_full()}
   - Edit: mailing_address.address
     button: |
       **Your mailing address:**
@@ -602,7 +602,7 @@ review:
   - Edit: landlord_person_name
     button: |
 	    **Landlord name:**
-      ${landlord.name.full(middle="full")}
+      ${landlord.name_full()}
     show if: landlord_type == "Person"
   - Edit: landlord_company_name
     button: |
@@ -617,7 +617,7 @@ review:
   - Edit: property_manager.name.first
     button: |
 	    **Property manager name:**
-	    ${property_manager.name.full(middle="full")}
+	    ${property_manager.name_full()}
     show if: landlord_has_agent and landlord_type == "Company"
   - Edit: landlord.address.address
     button: |


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>